### PR TITLE
Added toString() method in LatLong

### DIFF
--- a/tests/Treffynnon/Navigator/LatLongTest.php
+++ b/tests/Treffynnon/Navigator/LatLongTest.php
@@ -39,4 +39,12 @@ class LatLongTest extends PHPUnit_Framework_TestCase {
         );
     }
 
+    public function testToString()
+    {
+        $latitude = new N\Coordinate(42.77);
+        $longitude = new N\Coordinate(-2.86844);
+        $LatLong = new N\LatLong($latitude, $longitude);
+        $this->assertEquals($latitude . ',' . $longitude, (string) $LatLong);
+    }
+
 }


### PR DESCRIPTION
I'm using your library for some conversions between my domain objects and google maps integration. It's really convenient to have a toString() method on the LatLong object so I can directly output in view helpers.
